### PR TITLE
Add symlink and register DisableGamepad plugin

### DIFF
--- a/js
+++ b/js
@@ -1,0 +1,1 @@
+ska-controller-fix:js

--- a/ska-controller-fix:js/plugins.js
+++ b/ska-controller-fix:js/plugins.js
@@ -126,6 +126,6 @@ var $plugins =
 {"name":"deploy/ska_steam","status":true,"description":"SKA Steam Deploy","parameters":{"steamMode":"false"}},
 {"name":"deploy/ska_demo","status":true,"description":"SKA Demo","parameters":{"demoMode":"false","maxDays":"40"}},
  {"name":"deploy/ska_deploy","status":true,"description":"SKA Deploy","parameters":{}},
-+{"name":"DisableGamepad","status":true,"description":"Disable Game-pad","parameters":{}}
+{"name":"DisableGamepad","status":true,"parameters":{}}
  ];
 


### PR DESCRIPTION
## Summary
- ensure DisableGamepad plugin is reachable via `js/`
- register DisableGamepad in plugin list

## Testing
- `node - <<'NODE'
 global.Input = { updateGamepadState(){} };
 require('./js/DisableGamepad.js');
 console.assert(typeof Input.updateGamepadState === 'function');
 console.log('test passed');
 NODE`